### PR TITLE
Добавление индекса в таблицу zap2_ips

### DIFF
--- a/zapret.sql
+++ b/zapret.sql
@@ -91,6 +91,7 @@ CREATE TABLE `zap2_ips` (
   `resolved` int(1) NOT NULL DEFAULT '0',
   `domain` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
+  KEY `record_id` (`record_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
Огромное колличество запросов типа:
SELECT ip FROM zap2_ips WHERE record_id=1199;
с выборкой по не индексированному полю приводит к тому, что при каждом запросе БД проводит поиск перебирая все записи, что приводит к нагрузке на БД и заметному времени отработки.

Добавил индексы в  таблицу zap2_ips
