### PR TITLE
BUGFIX: Добавление индекса в таблицу zap2_ips.

### DIFF
--- a/zapret.sql
+++ b/zapret.sql
@@ -90,7 +90,7 @@ CREATE TABLE `zap2_ips` (
   `ip` varbinary(16) DEFAULT NULL,
   `resolved` int(1) NOT NULL DEFAULT '0',
   `domain` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
   KEY `record_id` (`record_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
При добавлении строки с индексом, забыл запятую в предыдущей строке.
